### PR TITLE
Relationships endpoints

### DIFF
--- a/app/controllers/api/v1/items/merchant_controller.rb
+++ b/app/controllers/api/v1/items/merchant_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Items::MerchantController < ApplicationController
+  def index
+    item = Item.find(params[:item_id])
+    render json: MerchantSerializer.new(Merchant.find(item.merchant.id))
+  end
+end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,3 +1,5 @@
 class Api::V1::Merchants::ItemsController < ApplicationController
-
+  def index
+    render json: ItemSerializer.new((Item.where(merchant_id: params[:merchant_id])))
+  end
 end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::Merchants::ItemsController < ApplicationController
+
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -3,5 +3,6 @@ class Invoice < ApplicationRecord
 
   belongs_to :customer
   belongs_to :merchant
+
   has_many :transactions
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :items, except: [:new, :edit]
       resources :merchants, except: [:new, :edit]
+
+      namespace :merchants do
+        resources :items, only: [:index]
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :items, except: [:new, :edit]
-      resources :merchants, except: [:new, :edit]
-
-      namespace :merchants do
-        resources :items, only: [:index]
+      resources :merchants, except: [:new, :edit] do
+        resources :items, only: [:index], module: :merchants
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :items, except: [:new, :edit]
+      resources :items, except: [:new, :edit] do
+        resources :merchant, only: [:index], module: :items
+        # get '/merchant', to: 'merchant#show', module: :items
+      end
+
       resources :merchants, except: [:new, :edit] do
         resources :items, only: [:index], module: :merchants
       end

--- a/spec/requests/api/v1/items/item_merchant_request_spec.rb
+++ b/spec/requests/api/v1/items/item_merchant_request_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Item Merchant endpoint' do
+  it 'returns the merchant associated with an item' do
+    item = create(:item)
+    merchant = item.merchant
+
+    get "/api/v1/items/#{item.id}/merchant"
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    item_merchant_json = JSON.parse(response.body, symbolize_names: true)
+    expect(item_merchant_json[:data].count).to eq(1)
+    # expect(item_merchant_json[:data])
+  end
+end

--- a/spec/requests/api/v1/items/item_merchant_request_spec.rb
+++ b/spec/requests/api/v1/items/item_merchant_request_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe 'Item Merchant endpoint' do
     expect(response.content_type).to eq("application/json")
 
     item_merchant_json = JSON.parse(response.body, symbolize_names: true)
-    expect(item_merchant_json[:data].count).to eq(1)
-    # expect(item_merchant_json[:data])
+    expect(item_merchant_json[:data][:id]).to eq(merchant.id.to_s)
+    expect(item_merchant_json[:data][:type]).to eq("merchant")
+    expect(item_merchant_json[:data][:attributes][:name]).to eq(merchant.name)
+    expect(item_merchant_json[:data][:relationships][:items][:data].first[:id]).to eq(item.id.to_s)
   end
 end

--- a/spec/requests/api/v1/merchants/merchant_items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_items_request_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Items endpoint' do
+  it 'returns all items associated with a merchant' do
+    merchant = create(:merchant)
+    3.times {create(:item, merchant: merchant)}
+    diff_merchant_item = create(:item)
+
+    get "/api/v1/merchants/#{merchant.id}/items"
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    merchant_items_json = JSON.parse(response.body, symbolize_names: true)
+    expect(merchant_items_json[:data].count).to eq(3)
+    expect(merchant_items_json[:data].first).to have_key(:id)
+    # expect(merchant_items_json[:data]) to not have item w id of last item
+  end
+end

--- a/spec/requests/api/v1/merchants/merchant_items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_items_request_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Merchant Items endpoint' do
     merchant_items_json = JSON.parse(response.body, symbolize_names: true)
     expect(merchant_items_json[:data].count).to eq(3)
     expect(merchant_items_json[:data].first).to have_key(:id)
-    # expect(merchant_items_json[:data]) to not have item w id of last item
+
+    expect(merchant_items_json[:data].none? { |item| item[:id] == diff_merchant_item.id }).to eq(true)
   end
 end


### PR DESCRIPTION
Adds and tests endpoints that show related records, including:
• `GET` `/api/v1/merchants/:id/items` => returns all items associated with a merchant
• `GET` `/api/v1/items/:id/merchant` => returns the merchant associated with an item